### PR TITLE
Fix body modification

### DIFF
--- a/lib/parser.py
+++ b/lib/parser.py
@@ -21,10 +21,7 @@ def get_method(request: str):
 
 
 def get_body(request: str):
-    lines = request.split('\n\r')[1:]
-    body = []
+    # Strip off the headers
+    _, body = request.split("\n\r", maxsplit=1)
 
-    for line in lines:
-        body.append(line.strip())
-
-    return '\n\r'.join(body)
+    return body


### PR DESCRIPTION
Previously the message body was being modified as a part of the process of removing the head. The code stripped out empty lines, but this breaks multipart/form-data,

  https://datatracker.ietf.org/doc/html/rfc2046#section-5.1